### PR TITLE
Fix task error handling

### DIFF
--- a/tasks/image.js
+++ b/tasks/image.js
@@ -19,11 +19,11 @@ module.exports = function (grunt) {
     async.eachLimit(this.files, 10, function (file, next) {
       var basename = path.basename(file.dest);
       var dir = file.dest.replace(basename, '');
-      
+
       if (!fs.existsSync(dir)) {
         fs.mkdirSync(dir);
       }
-      
+
       var optimizer = new Optimizer({
         src: file.src[0],
         dest: file.dest,
@@ -33,20 +33,22 @@ module.exports = function (grunt) {
       optimizer.optimize(function (error, data) {
         if (error) {
           grunt.warn(error);
+          return next(error);
         }
         grunt.log.writeln(
           chalk.green('✔ ') + file.src[0] + chalk.gray(' ->') +
-          chalk.gray(' before=') + chalk.yellow(filesize(data.original)) + 
-          chalk.gray(' after=') + chalk.cyan(filesize(data.optimized)) + 
+          chalk.gray(' before=') + chalk.yellow(filesize(data.original)) +
+          chalk.gray(' after=') + chalk.cyan(filesize(data.optimized)) +
           chalk.gray(' reduced=') + chalk.green.underline(filesize(data.diff) + '(' + data.diffPercent + '%)')
         );
-        process.nextTick(next);
+        next();
       });
     }, function (error) {
       if (error) {
         grunt.warn(error);
-        done();
+        return done(error);
       }
+      done();
     });
   });
 };


### PR DESCRIPTION
Thanks for greate module!

But on my Mac OS X, `image` task is finished before call next task.
When run `grunt test` on my machine, after `image` task, `'nodeunit' and 'clean'` never called.

I realized that some error handling and asynchronous task handling maybe wrong.
- If you use [async.eachLimit](https://github.com/caolan/async#eachLimit), must call next(errror) when error occured.
- [if task failed, must call `done(error)`](http://gruntjs.com/api/inside-tasks#this.async)
