### PR TITLE
Get original file size before optimize

### DIFF
--- a/tasks/lib/optimizer.js
+++ b/tasks/lib/optimizer.js
@@ -195,8 +195,8 @@ Optimizer.prototype.optimize = function (callback) {
     };
   });
 
+  var originalSize = fs.statSync(src).size;
   async.series(fns, function (error, result) {
-    var originalSize = fs.statSync(src).size;
     var optimizedSize = fs.statSync(dest).size;
     var diffSize = originalSize - optimizedSize;
     callback(error, {


### PR DESCRIPTION
If `cwd` and `dest` directory is same like this, original file size report optimized image size.

```
module.exports = function (grunt) {
  grunt.initConfig({
    image: {
      release: {
        files: [
          expand: true,
          cwd: 'build/img/',
          src: ['**/*.{png,jpg,gif}'],
          dest: 'build/img/'
        ]
      }
    }
  })
};
```
