### PR TITLE
Use the latest version of zopflipng-bin

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "pify": "^2.3.0",
     "pngquant-bin": "^3.1.0",
     "svgo": "^0.7.0",
-    "zopflipng-bin": "^3.0.1"
+    "zopflipng-bin": "^4.0.0"
   },
   "devDependencies": {
     "grunt": "^1.0.1",


### PR DESCRIPTION
**Resolves #24**

The latest version of zopflipng-bin (`4.0.0`) includes a patch for a known issue in macOS.

A version bump of grunt-image may also be needed.